### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/emjimadhu/eslint-formatter-formattify#readme",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/emjimadhu/eslint-formatter-formattify.git"
+    "url": "git+https://github.com/emjimadhu/eslint-formatter-formattify.git"
   },
   "files": [
     "dist/**/*"


### PR DESCRIPTION
## Summary

- update `repository.url` to use the public HTTPS GitHub URL

## Why

The package metadata currently points at `git+ssh://git@github.com/emjimadhu/eslint-formatter-formattify.git`. The repository is public, so tools and users reading npm/package metadata should be able to follow the source link without SSH or GitHub key setup.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/emjimadhu/eslint-formatter-formattify.git') throw new Error(JSON.stringify(p.repository)); console.log(JSON.stringify(p.repository))"`
- `git diff --check`
- `git ls-remote https://github.com/emjimadhu/eslint-formatter-formattify.git HEAD`
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn lint`
- `yarn build`
- `yarn pack --filename /tmp/eslint-formatter-formattify-4.1.0.tgz`

No runtime code, dependency, or lockfile changes are included.
